### PR TITLE
Fix Colab link

### DIFF
--- a/notebooks/DeepLearningIllustrated/shallow_net_in_tensorflow.ipynb
+++ b/notebooks/DeepLearningIllustrated/shallow_net_in_tensorflow.ipynb
@@ -2,19 +2,24 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Concrete Example of a Neural Network in TensorFlow"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/gpnlab/DL_BookClub/blob/master/notebooks/shallow_net_in_tensorflow.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/gpnlab/DL_BookClub/blob/master/notebooks/DeepLearningIllustrated/shallow_net_in_tensorflow.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "\n",
+    "No data download, tensorflow/pytorch installation, or modifications to the jupyter notebook required! Just follow the link and make sure to select a GPU as the hardware accelerator: \n",
+    "```\n",
+    "Runtime > Change runtime type > Hardware accelerator > Select GPU\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Concrete Example of a Neural Network in TensorFlow"
    ]
   },
   {


### PR DESCRIPTION
Fix link for the execution of Deep Learning Illustrated, Chapter 5's Jupyter notebook, in Colab.